### PR TITLE
all hostname should now be configured via ENV

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # environment file for docker-compose
 REPO=robotshop
-TAG=0.2.2
+TAG=0.2.4

--- a/cart/server.js
+++ b/cart/server.js
@@ -14,6 +14,9 @@ const express = require('express');
 
 var redisConnected = false;
 
+var redisHost = process.env.REDIS_HOST || 'redis'
+var catalogueHost = process.env.CATALOGUE_HOST || 'catalogue'
+
 const app = express();
 
 app.use((req, res, next) => {
@@ -284,7 +287,7 @@ function calcTax(total) {
 
 function getProduct(sku) {
     return new Promise((resolve, reject) => {
-        request('http://catalogue:8080/product/' + sku, (err, res, body) => {
+        request('http://' + catalogueHost + ':8080/product/' + sku, (err, res, body) => {
             if(err) {
                 reject(err);
             } else if(res.statusCode != 200) {
@@ -308,7 +311,7 @@ function saveCart(id, cart) {
 
 // connect to Redis
 var redisClient = redis.createClient({
-    host: 'redis'
+    host: redisHost
 });
 
 redisClient.on('error', (e) => {

--- a/dispatch/Dockerfile
+++ b/dispatch/Dockerfile
@@ -3,9 +3,11 @@ FROM golang:1.9.2
 WORKDIR /opt/gorcv
 
 ENV GOPATH=/opt/gorcv \
-    GOBIN=/opt/gorcv/bin
+    GOBIN=/opt/gorcv/bin \
+    AMQP_URI=rabbitmq
 
 # install external components
+# @todo godep
 RUN go get \
     github.com/streadway/amqp \
     github.com/instana/golang-sensor
@@ -13,6 +15,8 @@ RUN go get \
 COPY src /opt/gorcv/
 
 RUN go build && go install
+
+# @todo stage this build
 
 CMD bin/gorcv
 

--- a/dispatch/src/main.go
+++ b/dispatch/src/main.go
@@ -4,6 +4,7 @@ import (
     "fmt"
     "log"
     "time"
+    "os"
 
     "github.com/streadway/amqp"
     "github.com/instana/golang-sensor"
@@ -15,9 +16,8 @@ const (
     Service = "Dispatch"
 )
 
-var amqpUri string = "amqp://guest:guest@rabbitmq:5672/"
-
 var (
+    amqpUri string
     rabbitChan *amqp.Channel
     rabbitCloseError chan *amqp.Error
     rabbitReady chan bool
@@ -110,6 +110,9 @@ func main() {
     ot.InitGlobalTracer(instana.NewTracerWithOptions(&instana.Options{
         Service: Service,
         LogLevel: instana.Info}))
+
+    // Init amqpUri
+    amqpUri = fmt.Sprintf("amqp://guest:guest@%s:5672/", os.Getenv("AMQP_HOST"))
 
     // MQ error channel
     rabbitCloseError = make(chan *amqp.Error)

--- a/payment/rabbitmq.py
+++ b/payment/rabbitmq.py
@@ -1,8 +1,9 @@
 import json
 import pika
+import os
 
 class Publisher:
-    HOST = 'rabbitmq'
+    HOST = os.getenv("AMQP_HOST", "rabbitmq")
     VIRTUAL_HOST = '/'
     EXCHANGE='robot-shop'
     TYPE='direct'

--- a/shipping/service/Dockerfile
+++ b/shipping/service/Dockerfile
@@ -22,6 +22,9 @@ EXPOSE 8080
 
 WORKDIR /opt/shipping
 
+ENV CART_ENDPOINT=cart:8080
+ENV DB_HOST=mysql
+
 COPY --from=build /opt/shipping/target/shipping-1.0-jar-with-dependencies.jar shipping.jar
 
 CMD [ "java", "-jar", "shipping.jar" ]

--- a/shipping/service/src/main/java/org/steveww/spark/Main.java
+++ b/shipping/service/src/main/java/org/steveww/spark/Main.java
@@ -30,11 +30,17 @@ import java.util.List;
 import java.util.Map;
 
 public class Main {
-    private static String CART_URL = "http://cart:8080/shipping/";
+    private static String CART_URL = null;
+    private static String JDBC_URL = null;
     private static Logger logger = LoggerFactory.getLogger(Main.class);
     private static ComboPooledDataSource cpds = null;
 
     public static void main(String[] args) {
+        // Get ENV configuration values
+        Map<String, String> env = System.getenv();
+        CART_URL = String.format("http://%s/shipping/", env.get("CART_ENDPOINT"));
+        JDBC_URL = String.format("jdbc:mysql://%s/cities?useSSL=false&autoReconnect=true", env.get("DB_HOST"));
+
         //
         // Create database connector
         // TODO - might need a retry loop here
@@ -42,7 +48,7 @@ public class Main {
         try {
             cpds = new ComboPooledDataSource();
             cpds.setDriverClass( "com.mysql.jdbc.Driver" ); //loads the jdbc driver            
-            cpds.setJdbcUrl( "jdbc:mysql://mysql/cities?useSSL=false&autoReconnect=true" );
+            cpds.setJdbcUrl( JDBC_URL );
             cpds.setUser("shipping");                                  
             cpds.setPassword("secret");
             // some config

--- a/user/server.js
+++ b/user/server.js
@@ -196,7 +196,7 @@ app.get('/history/:id', (req, res) => {
 
 // connect to Redis
 var redisClient = redis.createClient({
-    host: 'redis'
+    host: process.env.REDIS_HOST || 'redis'
 });
 
 redisClient.on('error', (e) => {

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,9 +2,15 @@ FROM nginx:1.13.8
 
 EXPOSE 8080
 
+ENV CATALOGUE_HOST=catalogue \
+    USER_HOST=user \
+    CART_HOST=cart \
+    SHIPPING_HOST=shipping \
+    PAYMENT_HOST=payment
+
 COPY entrypoint.sh /root/
 ENTRYPOINT ["/root/entrypoint.sh"]
 
-COPY default.conf /etc/nginx/conf.d/default.conf
+COPY default.conf.template /etc/nginx/conf.d/default.conf.template
 COPY static /usr/share/nginx/html
 

--- a/web/default.conf.template
+++ b/web/default.conf.template
@@ -44,23 +44,23 @@ server {
     #}
 
     location /api/catalogue/ {
-        proxy_pass http://catalogue:8080/;
+        proxy_pass http://${CATALOGUE_HOST}:8080/;
     }
 
     location /api/user/ {
-        proxy_pass http://user:8080/;
+        proxy_pass http://${USER_HOST}:8080/;
     }
 
     location /api/cart/ {
-        proxy_pass http://cart:8080/;
+        proxy_pass http://${CART_HOST}:8080/;
     }
 
     location /api/shipping/ {
-        proxy_pass http://shipping:8080/;
+        proxy_pass http://${SHIPPING_HOST}:8080/;
     }
 
     location /api/payment/ {
-        proxy_pass http://payment:8080/;
+        proxy_pass http://${PAYMENT_HOST}:8080/;
     }
 
     location /nginx_status {

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -32,5 +32,8 @@ fi
 # make sure nginx can access the eum file
 chmod 644 $BASE_DIR/eum.html
 
+# apply environment variables to default.conf
+envsubst < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+
 exec nginx -g "daemon off;"
 


### PR DESCRIPTION
@steveww i spent a day trying to sort out overlay networking in dcos/marathon and i began contemplating performing a ritual sacrifice. i gave up trying to leverage host names which were friendly with what you had hard coded. hostnames should be configured via ENV params now, and will default to what you had set already.

i'm almost ready to package up the json specs, but not quite there (need to implement the instana agent install via dcos as well). in any case, this PR can merge before that work is done.

