### PR TITLE
Adding a custom prometheus metric to the cart

### DIFF
--- a/cart/package.json
+++ b/cart/package.json
@@ -16,6 +16,7 @@
       "pino": "^5.10.8",
       "express-pino-logger": "^4.0.0",
       "pino-pretty": "^2.5.0",
-      "@instana/collector": "^1.65.0"
+      "@instana/collector": "^1.65.0",
+      "prom-client": "^11.5.3"
   }
 }

--- a/cart/server.js
+++ b/cart/server.js
@@ -31,6 +31,12 @@ const expLogger = expPino({
     logger: logger
 });
 
+const counter = new client.Counter({
+    name: 'cart_items_total',
+    help: 'all items in all carts.',
+    registers: [register]
+});
+
 const app = express();
 
 app.use(expLogger);

--- a/cart/server.js
+++ b/cart/server.js
@@ -13,6 +13,9 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const pino = require('pino');
 const expPino = require('express-pino-logger');
+const client = require('prom-client');
+const Registry = client.Registry;
+const register = new Registry();
 
 var redisConnected = false;
 
@@ -49,6 +52,10 @@ app.get('/health', (req, res) => {
     res.json(stat);
 });
 
+// prometheus metrics
+app.get('/metrics', (req, res) => {
+    res.send(register.metrics());
+});
 
 // get cart with id
 app.get('/cart/:id', (req, res) => {
@@ -165,6 +172,7 @@ app.get('/add/:id/:sku/:qty', (req, res) => {
 
                 // save the new cart
                 saveCart(req.params.id, cart).then((data) => {
+                    counter.inc(qty);
                     res.json(cart);
                 }).catch((err) => {
                     req.log.error(err);


### PR DESCRIPTION
Didn't know where to put it.

For prometheus customers would need additional config:

``` 
    # Kubernetes Discovery Prometheus Configuration
    com.instana.plugin.prometheus:
      customMetricSources:
      - url: '/metrics' # url path part which expose metrics
        metricNameIncludeRegex: '^cart'
``` 