### PR TITLE
fixed reconnection to rabbitmq in payment app

### DIFF
--- a/payment/rabbitmq.py
+++ b/payment/rabbitmq.py
@@ -19,7 +19,7 @@ class Publisher:
         self._channel = None
 
     def _connect(self):
-        if not self._conn or self._conn.is_closed:
+        if not self._conn or self._conn.is_closed or self._channel is None or self._channel.is_closed:
             self._conn = pika.BlockingConnection(self._params)
             self._channel = self._conn.channel()
             self._channel.exchange_declare(exchange=self.EXCHANGE, exchange_type=self.TYPE, durable=True)
@@ -34,7 +34,7 @@ class Publisher:
 
     #Publish msg, reconnecting if necessary.
     def publish(self, msg, headers):
-        if self._channel is None:
+        if self._channel is None or self._channel.is_closed or self._conn is None or self._conn.is_closed:
             self._connect()
         try:
             self._publish(msg, headers)


### PR DESCRIPTION
Fixing reconnect to RabbitMQ in payment app. After losing connection to RabbitMQ, payment application is not able to reconnect.

Error from logs:
<class 'pika.exceptions.ChannelWrongStateError'> Channel is closed.

Issue can be found in following link:
https://demous-instana.instana.io/#/analyze;callList.dataSource=traces;callList.tagFilter=!(name~service.name~value~payment~operator~EQUALS)(name~trace.erroneous~value~true~operator~EQUALS)(name~trace.endpoint.name~value~payment~operator~EQUALS~secondLevelName~*)~;callList.groupBy=()~/trace;traceId=ed935bfe3680d804;callId=93c5fe8efcf0e43d/tree?timeline.to&timeline.ws=3600000&eventId=dnIQGBrkRqqrq0TwpbFMZw
