### PR TITLE
Create load service docker-compose file

### DIFF
--- a/docker-compose.load.yaml
+++ b/docker-compose.load.yaml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  load:
+    image: ${REPO}/rs-load:${TAG}
+    environment:
+      HOST: http://web:8080
+    networks:
+      - robot-shop
+    depends_on:
+      - web

--- a/docker-compose.load.yaml
+++ b/docker-compose.load.yaml
@@ -2,6 +2,8 @@ version: '3'
 services:
   load:
     image: ${REPO}/rs-load:${TAG}
+    build:
+      context: load-gen
     environment:
       HOST: http://web:8080
     networks:


### PR DESCRIPTION
This addition makes it easy to start into a load scenario right
away with docker-compose, by referencing 2 docker-compose files.

By default, only the file with the services will be loaded, for
starting the load-gen right away, use
`docker-compose -f docker-compose.yaml -f docker-compose.load.yaml OPERATION`

The given config will use the internal container network to
produce some load.