### PR TITLE
Install robot-shop with a minimal pod security policy and associated RBAC resources

### DIFF
--- a/K8s/descriptors/cart-deployment.yaml
+++ b/K8s/descriptors/cart-deployment.yaml
@@ -14,10 +14,11 @@ spec:
       labels:
         service: cart
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: cart
         image: robotshop/rs-cart:latest
-        # agent networking access 
+        # agent networking access
         env:
           - name: INSTANA_AGENT_HOST
             valueFrom:

--- a/K8s/descriptors/catalogue-deployment.yaml
+++ b/K8s/descriptors/catalogue-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         service: catalogue
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: catalogue
         image: robotshop/rs-catalogue:latest

--- a/K8s/descriptors/clusterrole.yaml
+++ b/K8s/descriptors/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: robot-shop
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - robot-shop
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/K8s/descriptors/clusterrolebinding.yaml
+++ b/K8s/descriptors/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: robot-shop
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: robot-shop
+subjects:
+- kind: ServiceAccount
+  name: robot-shop
+  namespace: robot-shop

--- a/K8s/descriptors/dispatch-deployment.yaml
+++ b/K8s/descriptors/dispatch-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         service: dispatch
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: dispatch
         image: robotshop/rs-dispatch:latest

--- a/K8s/descriptors/mongodb-deployment.yaml
+++ b/K8s/descriptors/mongodb-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         service: mongodb
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: mongodb
         image: robotshop/rs-mongodb:latest

--- a/K8s/descriptors/mysql-deployment.yaml
+++ b/K8s/descriptors/mysql-deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: mysql
         image: robotshop/rs-mysql-db:latest

--- a/K8s/descriptors/payment-deployment.yaml
+++ b/K8s/descriptors/payment-deployment.yaml
@@ -17,6 +17,7 @@ spec:
         service: payment
         stage: prod
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: payment
         image: robotshop/rs-payment:latest

--- a/K8s/descriptors/podsecuritypolicy.yaml
+++ b/K8s/descriptors/podsecuritypolicy.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: robot-shop
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  privileged: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  allowedCapabilities:
+  - 'NET_ADMIN'
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - secret
+  - projected

--- a/K8s/descriptors/rabbitmq-deployment.yaml
+++ b/K8s/descriptors/rabbitmq-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         service: rabbitmq
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: rabbitmq
         image: rabbitmq:3.7-management-alpine

--- a/K8s/descriptors/ratings-deployment.yaml
+++ b/K8s/descriptors/ratings-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         service: ratings
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: ratings
         image: robotshop/rs-ratings:latest

--- a/K8s/descriptors/redis-deployment.yaml
+++ b/K8s/descriptors/redis-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         service: redis
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: redis
         image: redis:4.0.6

--- a/K8s/descriptors/serviceaccount.yaml
+++ b/K8s/descriptors/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: robot-shop
+  namespace: robot-shop

--- a/K8s/descriptors/shipping-deployment.yaml
+++ b/K8s/descriptors/shipping-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         service: shipping
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: shipping
         image: robotshop/rs-shipping:latest

--- a/K8s/descriptors/user-deployment.yaml
+++ b/K8s/descriptors/user-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         service: user
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: user
         image: robotshop/rs-user:latest

--- a/K8s/descriptors/web-deployment.yaml
+++ b/K8s/descriptors/web-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         service: web
     spec:
+      serviceAccountName: robot-shop
       containers:
       - name: web
         image: robotshop/rs-web:latest


### PR DESCRIPTION
To apply, use the usual command `kubectl apply -f K8s/descriptors/ -n robot-shop`

~This should't be merged until we can toggle the creation of the pod security policy and associated RBAC resources on and off on demand, or unless we decide that we'll create the pod security policy  resources anyway, regardless of whether pod security policies are enabled on the target cluster or not.~

This actually could be applied safely to a target cluster that does not have the pod security policy admission controller enabled. Just a question of whether we want these k8s resources to be created by default.