### PR TITLE
Enable PHP profiling for ratings service

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # environment file for docker-compose
 REPO=robotshop
-TAG=0.5.1
+TAG=0.5.2

--- a/ratings/Dockerfile
+++ b/ratings/Dockerfile
@@ -8,9 +8,12 @@ RUN composer install
 #
 # Build the app
 #
-FROM php:7.3-apache
+FROM php:7.4-apache
 
 RUN docker-php-ext-install pdo_mysql
+
+# Enable AutoProfile for PHP which is currently opt-in beta
+RUN echo "instana.enable_auto_profile=1" > "/usr/local/etc/php/conf.d/zzz-instana-extras.ini"
 
 # relax permissions on status
 COPY status.conf /etc/apache2/mods-available/status.conf


### PR DESCRIPTION
This enables the opt-in only PHP profiling for the ratings-service - and upgrades PHP to 7.4.

![image](https://user-images.githubusercontent.com/418970/95083643-16a09200-071d-11eb-9b76-e206c3183aaa.png)
