### PR TITLE
Add redis.storageClassName to permit an override of the storage class

### DIFF
--- a/K8s/helm/README.md
+++ b/K8s/helm/README.md
@@ -93,3 +93,4 @@ $ helm install robot-shop --set openshift=true helm
 | openshift        | false | boolean | If OpenShift additional configuration is applied. |
 | payment.gateway  | null | string | External URL end-point to simulate partial/3rd party traces. |
 | psp.enabled      | false | boolean | Enable Pod Security Policy for clusters with a PSP Admission controller |
+| redis.storageClassName | standard | string | Storage class to use with Redis's StatefulSet. The default for EKS is gp2. |

--- a/K8s/helm/templates/redis-statefulset.yaml
+++ b/K8s/helm/templates/redis-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       spec:
         accessModes: [ "ReadWriteOnce" ]
         {{ if not .Values.openshift }}
-        storageClassName: standard
+        storageClassName: {{ .Values.redis.storageClassName }}
         volumeMode: Filesystem
         {{ end }}
         resources:

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -28,3 +28,6 @@ nodeport: false
 # "special" Openshift. Set to true when deploying to any openshift flavour
 openshift: false
 
+# Storage class to use with redis statefulset.
+redis:
+  storageClassName: standard


### PR DESCRIPTION
## Why

The redis pod was converted to a statefulset using the storageClassName.
Depending on where your Kubernetes cluster resides this storage class name might
not exist. In order to make it easy to onboard into different cloud providers
easily this PR aims to allow specifying the storage class name during helm
install.

## What

Add `redis.storageClassName` that allows specification of the storage class name.
