### PR TITLE
Install opcache PHP extension

### DIFF
--- a/ratings/Dockerfile
+++ b/ratings/Dockerfile
@@ -10,7 +10,7 @@ RUN composer install
 #
 FROM php:7.4-apache
 
-RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pdo_mysql opcache
 
 # Enable AutoProfile for PHP which is currently opt-in beta
 RUN echo "instana.enable_auto_profile=1" > "/usr/local/etc/php/conf.d/zzz-instana-extras.ini"


### PR DESCRIPTION
This will enable the PHP extension to send opcache metrics.