### PR TITLE
fix CORS error issue

### DIFF
--- a/web/static/eum-tmpl.html
+++ b/web/static/eum-tmpl.html
@@ -8,6 +8,6 @@
   ineum('trackSessions');
   ineum('page', 'splash');
 </script>
-<script defer crossorigin="anonymous" src="https://eum.instana.io/eum.min.js"></script>
+<script defer crossorigin="anonymous" src="INSTANA_EUM_REPORTING_URL/eum.min.js"></script>
 <!-- EUM include end -->
 


### PR DESCRIPTION
Originally, the template has hardcoded the URL for `eum.min.js`:

```javascript
<!-- EUM include -->
<script>
  (function(s,t,a,n){s[t]||(s[t]=a,n=s[a]=function(){n.q.push(arguments)},
  n.q=[],n.v=2,n.l=1*new Date)})(window,"InstanaEumObject","ineum");

  ineum('reportingUrl', 'INSTANA_EUM_REPORTING_URL');
  ineum('key', 'INSTANA_EUM_KEY');
  ineum('trackSessions');
  ineum('page', 'splash');
</script>
<script defer crossorigin="anonymous" src="https://eum.instana.io/eum.min.js"></script>
<!-- EUM include end -->
```

When we generate the website in Instana we may get the `reportingUrl` from a different domain, say `https://eum-orange-saas.instana.io`.

In this case, an CORS error will happen in modern browsers like Chrome:
![cors](https://user-images.githubusercontent.com/1422425/120774890-4c6c7380-c555-11eb-8227-d74f06e0a740.jpg)

And the proven solution is simply to make that URL the same as the `reportingUrl`, as what the PR fixes.
