### PR TITLE
add selenium-based website load gen

### DIFF
--- a/selenium/Dockerfile
+++ b/selenium/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3-slim
+
+# The URL of Robot Shop
+ENV HOST=""
+
+# Install Chromium and Chrome WebDriver
+RUN \
+    apt-get update && \
+    apt-get install -y wget curl unzip gnupg2 && \
+    \
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+    apt-get update && \
+    apt-get install -y gnupg2 google-chrome-stable && \
+    \
+    CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` && \
+    mkdir -p /opt/chromedriver-$CHROMEDRIVER_VERSION && \
+    curl -sS -o /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
+    unzip -qq /tmp/chromedriver_linux64.zip -d /opt/chromedriver-$CHROMEDRIVER_VERSION && \
+    rm /tmp/chromedriver_linux64.zip && \
+    chmod +x /opt/chromedriver-$CHROMEDRIVER_VERSION/chromedriver && \
+    ln -fs /opt/chromedriver-$CHROMEDRIVER_VERSION/chromedriver /usr/local/bin/chromedriver && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /load
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY entrypoint.sh /load/
+COPY load.py /load/
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/selenium/Dockerfile
+++ b/selenium/Dockerfile
@@ -22,12 +22,15 @@ RUN \
     ln -fs /opt/chromedriver-$CHROMEDRIVER_VERSION/chromedriver /usr/local/bin/chromedriver && \
     rm -rf /var/lib/apt/lists/*
 
+RUN useradd -m loader
+USER loader
+
 WORKDIR /load
 
-COPY requirements.txt ./
+COPY --chown=loader:loader requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY entrypoint.sh /load/
-COPY load.py /load/
+COPY --chown=loader:loader entrypoint.sh .
+COPY --chown=loader:loader load.py .
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/selenium/README.md
+++ b/selenium/README.md
@@ -28,9 +28,7 @@ docker run --name rs-website-load -e HOST -d robotshop/rs-website-load
 ## Run it on Kubernetes / OpenShift
 
 ```sh
-export HOST="<YOUR ROBOT SHOP HOST URL>"
-
-kubectl apply -f - <<EOF
+kubectl -n robot-shop apply -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,8 +49,8 @@ spec:
       - name: rs-website-load
         env:
           - name: HOST
-            value: "$HOST"
-        image: robotshop/rs-website-load:latest
-        #image: brightzheng100/rs-website-load:latest
+            value: "http://web:8080/"                 # or your robot shop app's real route URL
+        #image: robotshop/rs-website-load:latest
+        image: brightzheng100/rs-website-load:latest
 EOF
 ```

--- a/selenium/README.md
+++ b/selenium/README.md
@@ -1,0 +1,58 @@
+# Selenium-based load generator for website monitoring
+
+This is a load generator from an end-user perspective to simulate browser behaviours to generate traffic for website monitoring.
+
+## Build and publish the image
+
+Below command will build the image and tag it as both `${REPO}/rs-website-load:${TAG}` and `${REPO}/rs-website-load:latest`, where the `${REPO}` and `${TAG}` come from file of [`../.env`](../.env).
+
+```sh
+$ ./build.sh
+```
+
+Adding flag of `push` in the command will push the image to the configured repository, which is Docker Hub by default:
+
+```sh
+$ ./build.sh push
+```
+
+## Run it locally
+
+```sh
+export HOST="<YOUR ROBOT SHOP HOST URL>"
+docker run --name rs-website-load -e HOST -d robotshop/rs-website-load
+```
+
+> Note: to stop it, run `docker stop rs-website-load`; to delete it, run `docker rm -f rs-website-load`.
+
+## Run it on Kubernetes / OpenShift
+
+```sh
+export HOST="<YOUR ROBOT SHOP HOST URL>"
+
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rs-website-load
+  labels:
+    service: rs-website-load
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: rs-website-load
+  template:
+    metadata:
+      labels:
+        service: rs-website-load
+    spec:
+      containers:
+      - name: rs-website-load
+        env:
+          - name: HOST
+            value: "$HOST"
+        image: robotshop/rs-website-load:latest
+        #image: brightzheng100/rs-website-load:latest
+EOF
+```

--- a/selenium/build.sh
+++ b/selenium/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# get the tag info
+eval $(egrep '[A-Z]+=' ../.env)
+
+echo "Repo $REPO"
+echo "Tag $TAG"
+
+docker build -t ${REPO}/rs-website-load:${TAG} . && docker tag ${REPO}/rs-website-load:${TAG} ${REPO}/rs-website-load
+
+if [ "$1" = "push" ]
+then
+    echo "pushing..."
+    docker push ${REPO}/rs-website-load:${TAG}
+    docker push ${REPO}/rs-website-load
+fi

--- a/selenium/entrypoint.sh
+++ b/selenium/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# set -x
+
+echo "-->HOST: $HOST"
+
+# wait for selenium to be ready
+sleep 5
+
+i=1
+while true; do
+    python load.py "$HOST" "round-$i"
+    ((i++))
+    sleep 1
+done

--- a/selenium/load.py
+++ b/selenium/load.py
@@ -1,0 +1,55 @@
+import sys,time
+from selenium import webdriver 
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+
+# parameters
+HOST=sys.argv[1]
+ROUND=sys.argv[2]
+
+chrome_options = Options()
+chrome_options.add_argument("--disable-extensions")
+chrome_options.add_argument("--disable-gpu")
+chrome_options.add_argument("--no-sandbox")
+chrome_options.add_argument("--headless")
+chrome_options.add_argument("--use--fake-ui-for-media-stream")
+
+driver = webdriver.Chrome(options=chrome_options)
+
+print("-->START:" + ROUND)
+
+driver.get(HOST)
+
+driver.find_element(By.LINK_TEXT, "Login / Register").click()
+time.sleep(1)
+driver.find_element(By.XPATH, "/html/body/div/div[1]/div[2]/div/div/div[2]/table[1]/tbody/tr[1]/td[2]/input").click()
+driver.find_element(By.XPATH, "/html/body/div/div[1]/div[2]/div/div/div[2]/table[1]/tbody/tr[1]/td[2]/input").send_keys("stan")
+driver.find_element(By.XPATH, "//input[@type=\'password\']").click()
+driver.find_element(By.XPATH, "//input[@type=\'password\']").send_keys("bigbrain")
+driver.find_element(By.XPATH, "//button[contains(.,\'Login\')]").click()
+time.sleep(1)
+driver.find_element(By.XPATH, "//span[contains(.,\'Artificial Intelligence\')]").click()
+time.sleep(1)
+driver.find_element(By.XPATH, "//a[contains(text(),\'Ewooid\')]").click()
+time.sleep(0.5)
+driver.find_element(By.ID, "vote-4").click()
+driver.find_element(By.LINK_TEXT, "Stan").click()
+time.sleep(0.5)
+driver.find_element(By.CSS_SELECTOR, ".ng-scope > button").click()
+driver.find_element(By.LINK_TEXT, "Watson").click()
+time.sleep(0.5)
+driver.find_element(By.XPATH, "//button[contains(.,\'Add to cart\')]").click()
+driver.find_element(By.XPATH, "//span[contains(.,\'Robot\')]").click()
+time.sleep(0.5)
+driver.find_element(By.LINK_TEXT, "Cybernated Neutralization Android").click()
+time.sleep(0.5)
+driver.find_element(By.ID, "vote-5").click()
+driver.find_element(By.LINK_TEXT, "Cart").click()
+time.sleep(0.5)
+driver.find_element(By.XPATH, "//button[contains(.,\'Checkout\')]").click()
+
+print("-->END:" + ROUND)
+
+driver.close()

--- a/selenium/load.py
+++ b/selenium/load.py
@@ -1,4 +1,4 @@
-import sys,time
+import sys,time,random
 from selenium import webdriver 
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
@@ -13,15 +13,32 @@ chrome_options = Options()
 chrome_options.add_argument("--disable-extensions")
 chrome_options.add_argument("--disable-gpu")
 chrome_options.add_argument("--no-sandbox")
+chrome_options.add_argument('--disable-dev-shm-usage')
 chrome_options.add_argument("--headless")
-chrome_options.add_argument("--use--fake-ui-for-media-stream")
+chrome_options.add_experimental_option("prefs", { "profile.default_content_setting_values.geolocation": 1})
 
 driver = webdriver.Chrome(options=chrome_options)
+
+# Honolulu: 21.3281792,-157.8691131
+# Mauritius: -21.0752381,57.0387649
+# South Africa: -33.914651,18.3758793
+# China: 30.2325248,120.1400391
+latitude = [21.3281792,-21.0752381,-33.914651,30.2325248]
+longitude = [-157.8691131,57.0387649,18.3758793,120.1400391]
+i = random.choice([0, 1, 2, 3])
+driver.execute_cdp_cmd(
+    "Emulation.setGeolocationOverride",
+    {
+        "latitude": latitude[i],
+        "longitude": longitude[i],
+        "accuracy": 100,
+    },
+)
 
 print("-->START:" + ROUND)
 
 driver.get(HOST)
-
+time.sleep(2)
 driver.find_element(By.LINK_TEXT, "Login / Register").click()
 time.sleep(1)
 driver.find_element(By.XPATH, "/html/body/div/div[1]/div[2]/div/div/div[2]/table[1]/tbody/tr[1]/td[2]/input").click()
@@ -52,4 +69,4 @@ driver.find_element(By.XPATH, "//button[contains(.,\'Checkout\')]").click()
 
 print("-->END:" + ROUND)
 
-driver.close()
+driver.quit()

--- a/selenium/requirements.txt
+++ b/selenium/requirements.txt
@@ -1,0 +1,1 @@
+selenium


### PR DESCRIPTION
This PR brings in a simple but complete Selenium-based load generator to easily help populate "Website Monitoring" dashboard for the Robot Shop demo app.
![Website Monitoring View](https://user-images.githubusercontent.com/1422425/121285418-f579ec00-c910-11eb-99ec-c705ca9bdefd.png)


The existing `code-gen` can help a lot generate the traffic for Application Perspectives (AP) but not for Website Monitoring.

The README.md in this PR provides details for how to build, run locally, or run on K8s/OpenShift too.
