### PR TITLE
helm/web-deployment: add env vars for log level of autotrace_webhook

### DIFF
--- a/K8s/helm/README.md
+++ b/K8s/helm/README.md
@@ -62,7 +62,7 @@ $ helm install \
 
 ## Use with Minis
 
-When running on `minishift` or `minikube` set `nodeport` to true. The store will then be available on the IP address of your mini and node port of the web service.
+When running on `minishift` or `minikube` set `web.nodeport` to true. The store will then be available on the IP address of your mini and node port of the web service.
 
 ```shell
 $ mini[kube|shift] ip
@@ -82,16 +82,17 @@ $ helm install robot-shop --set openshift=true helm
 
 ### Deployment Parameters
 
-| Key              | Default | Type   | Description |
-| ---------------- | ------- | ------ | ----------- |
-| eum.key          | null    | string | EUM Access Key |
-| eum.url          | https://eum-eu-west-1.instana.io | url | EUM endpoint URL |
-| image.pullPolicy | IfNotPresent | string | Kubernetes pull policy. One of Always,IfNotPresent, or Never. |
-| image.repo       | robotshop | string | Base docker repository to pull the images from. |
-| image.version    | latest | string | Docker tag to pull. |
-| nodeport         | false | booelan | Whether to expose the services via node port. |
-| openshift        | false | boolean | If OpenShift additional configuration is applied. |
-| payment.gateway  | null | string | External URL end-point to simulate partial/3rd party traces. |
-| psp.enabled      | false | boolean | Enable Pod Security Policy for clusters with a PSP Admission controller |
+| Key                    | Default | Type   | Description |
+| ----------------       | ------- | ------ | ----------- |
+| eum.key                | null    | string | EUM Access Key |
+| eum.url                | https://eum-eu-west-1.instana.io | url | EUM endpoint URL |
+| image.pullPolicy       | IfNotPresent | string | Kubernetes pull policy. One of Always,IfNotPresent, or Never. |
+| image.repo             | robotshop | string | Base docker repository to pull the images from. |
+| image.version          | latest | string | Docker tag to pull. |
+| web.nodeport           | false | boolean | Whether to expose the services via node port. |
+| web.debug_autotrace    | false | boolean | Whether to log in debug level the autotrace NGINX functionality |
+| openshift              | false | boolean | If OpenShift additional configuration is applied. |
+| payment.gateway        | null | string | External URL end-point to simulate partial/3rd party traces. |
+| psp.enabled            | false | boolean | Enable Pod Security Policy for clusters with a PSP Admission controller |
 | redis.storageClassName | standard | string | Storage class to use with Redis's StatefulSet. The default for EKS is gp2. |
-| ocCreateRoute    | false | boolean | If you are running on OpenShift and need a Route to the web service, set this to `true` |
+| ocCreateRoute          | false | boolean | If you are running on OpenShift and need a Route to the web service, set this to `true` |

--- a/K8s/helm/templates/web-deployment.yaml
+++ b/K8s/helm/templates/web-deployment.yaml
@@ -21,8 +21,15 @@ spec:
       - name: web
         image: {{ .Values.image.repo }}/rs-web:{{ .Values.image.version }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.eum.key }}
+        {{- if or .Values.web.debug_autotrace .Values.eum.key }}
         env:
+        {{- end}}
+        {{- if .Values.web.debug_autotrace }}
+        - name: INSTANA_LII_LOG_LEVEL
+          value: "debug"
+        - name: INSTANA_IWN_LOG_LEVEL
+          value: "debug"
+        {{- else if .Values.eum.key }}
         - name: INSTANA_EUM_KEY
           value: {{ .Values.eum.key }}
         - name: INSTANA_EUM_REPORTING_URL

--- a/K8s/helm/templates/web-service.yaml
+++ b/K8s/helm/templates/web-service.yaml
@@ -11,7 +11,7 @@ spec:
     targetPort: 8080
   selector:
     service: web
-  {{ if .Values.nodeport }}
+  {{ if .Values.web.nodeport }}
   type: NodePort
   {{ else }}
   type: LoadBalancer

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -22,8 +22,12 @@ eum:
 psp:
   enabled: false
 
-# For the mini ones minikube, minishift set to true
-nodeport: false
+
+web:
+  # autotrace-webhook binaries to log in debug level
+  debug_autotrace: false
+  # For the mini ones minikube, minishift set to true
+  nodeport: false
 
 # "special" Openshift. Set to true when deploying to any openshift flavour
 openshift: false


### PR DESCRIPTION
These environment variables come useful during debugging when the autotrace
webhook is used.

Signed-off-by: Antonio Gutierrez <antonio.gutierrez@instana.com>