### PR TITLE
Update nginx tracing and server versions

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,19 +5,24 @@ WORKDIR /instana
 
 RUN apk add --update --no-cache curl
 
-RUN if [ -n "$KEY" ]; then curl \
+ENV ARTI_PATH='https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/'
+
+RUN if [ -n "$KEY" ]; then \
+    sensor_version=$(curl --user "_:$KEY" ${ARTI_PATH} | grep -o '>[0-9]\+\.[0-9]\+\.[0-9]\+'| cut -f 2 -d '>'|sort -V|tail -1 ); \
+    echo "Downloading sensor version ${sensor_version} for Nginx version 1.21.6" ; \
+    curl \
     --output instana.zip \
     --user "_:$KEY" \
-    https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.2/linux-amd64-glibc-nginx-1.20.1.zip && \
+    ${ARTI_PATH}/${sensor_version}/linux-amd64-glibc-nginx-1.21.6.zip && \
     unzip instana.zip && \
     mv glibc-libinstana_sensor.so libinstana_sensor.so && \
-    mv glibc-nginx-1.20.1-ngx_http_ot_module.so ngx_http_opentracing_module.so; \
+    mv glibc-nginx-1.21.6-ngx_http_ot_module.so ngx_http_opentracing_module.so; \
     else echo "KEY not provided. Not adding tracing"; \
     touch dummy.so; \
     fi
 
 
-FROM nginx:1.20.1
+FROM nginx:1.21.6
 
 EXPOSE 8080
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,20 +5,17 @@ WORKDIR /instana
 
 RUN apk add --update --no-cache curl
 
-RUN if [ -n "$KEY" ]; then nginx_version='1.5.0' \
-    curl --output index.html --user "_:$KEY" https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/ \
-    nginx_version=$(cat index.html |egrep "a href"| tail -1 | awk '{print $2;}'|sed 's/href="//'|sed 's/\/".*//') \
-    rm index.html \
-    curl \
-     --output instana.zip \
-     --user "_:$KEY" \
-     https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/$nginx_version/linux-amd64-nginx-1.20.1.zip && \
-     unzip instana.zip && \
-     mv glibc-libinstana_sensor.so libinstana_sensor.so && \
-     mv glibc-nginx-1.20.1-ngx_http_ot_module.so ngx_http_opentracing_module.so; \
+RUN if [ -n "$KEY" ]; then curl \
+    --output instana.zip \
+    --user "_:$KEY" \
+    https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.2/linux-amd64-glibc-nginx-1.20.1.zip && \
+    unzip instana.zip && \
+    mv glibc-libinstana_sensor.so libinstana_sensor.so && \
+    mv glibc-nginx-1.20.1-ngx_http_ot_module.so ngx_http_opentracing_module.so; \
     else echo "KEY not provided. Not adding tracing"; \
-        touch dummy.so; \
+    touch dummy.so; \
     fi
+
 
 FROM nginx:1.20.1
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,17 +5,20 @@ WORKDIR /instana
 
 RUN apk add --update --no-cache curl
 
-RUN if [ -n "$KEY" ]; then curl \
-    --output instana.zip \
-    --user "_:$KEY" \
-    https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.2/linux-amd64-glibc-nginx-1.20.1.zip && \
-    unzip instana.zip && \
-    mv glibc-libinstana_sensor.so libinstana_sensor.so && \
-    mv glibc-nginx-1.20.1-ngx_http_ot_module.so ngx_http_opentracing_module.so; \
+RUN if [ -n "$KEY" ]; then nginx_version='1.5.0' \
+    curl --output index.html --user "_:$KEY" https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/ \
+    nginx_version=$(cat index.html |egrep "a href"| tail -1 | awk '{print $2;}'|sed 's/href="//'|sed 's/\/".*//') \
+    rm index.html \
+    curl \
+     --output instana.zip \
+     --user "_:$KEY" \
+     https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/$nginx_version/linux-amd64-nginx-1.20.1.zip && \
+     unzip instana.zip && \
+     mv glibc-libinstana_sensor.so libinstana_sensor.so && \
+     mv glibc-nginx-1.20.1-ngx_http_ot_module.so ngx_http_opentracing_module.so; \
     else echo "KEY not provided. Not adding tracing"; \
-    touch dummy.so; \
+        touch dummy.so; \
     fi
-
 
 FROM nginx:1.20.1
 


### PR DESCRIPTION
# References

- [Kanbanize Card](https://instana.kanbanize.com/ctrl_board/64/)

# WHAT

Changed web/Dockerfile:
1. Update NGINX server version;
2. Implement a logicic for the download of the last available Instana Nginx sensor.

# WHY

- 2 Improvements for an end-user experience always up to the state of art.

# TESTS

Manual Testing against magenta environment. 

The default Nginx version is 1.21.6. If the variable nginx_version is not set in docker-compose.yaml, the version 1.21.6 is downloaded for rs-web docker image:

The host in the infrastructure shows the correct Nginx server version.

![image](https://user-images.githubusercontent.com/85874226/165769080-796665b6-b490-4bc2-9782-9a27610c8b44.png)



