### PR TITLE
Fix "cart" service label in helm chart

### DIFF
--- a/K8s/helm/templates/cart-service.yaml
+++ b/K8s/helm/templates/cart-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cart
+  labels:
+    service: cart
 spec:
   ports:
   - name: http


### PR DESCRIPTION
I've found out the bug in Helm chart, which messed up the `ServiceMonitor` setup for my Prometheus lab. It turns out the `metadata.labels.service` was missing – and ServiceMonitor failed to picked up the service, cause the lable wasn't there.

This fix would be very useful for monitoring `cart` service via Prometheus ;)