### PR TITLE
Allow external redis connection for cart and user services

### DIFF
--- a/K8s/helm/templates/cart-deployment.yaml
+++ b/K8s/helm/templates/cart-deployment.yaml
@@ -27,6 +27,22 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          {{ if .Values.appRedisConnection.host }}
+          - name: REDIS_HOST
+            value: {{ .Values.appRedisConnection.host | quote }}
+          {{ end }}
+          {{ if .Values.appRedisConnection.port }}
+          - name: REDIS_PORT
+            value: {{ .Values.appRedisConnection.port | quote }}
+          {{ end }}
+          {{ if .Values.appRedisConnection.db }}
+          - name: REDIS_DB
+            value: {{ .Values.appRedisConnection.db | quote }}
+          {{ end }}
+          {{ if .Values.appRedisConnection.sslCrt }}
+          - name: REDIS_SSL_CRT
+            value: {{ .Values.appRedisConnection.sslCrt | quote }}
+          {{ end }}
         ports:
         - containerPort: 8080
         resources:

--- a/K8s/helm/templates/user-deployment.yaml
+++ b/K8s/helm/templates/user-deployment.yaml
@@ -27,6 +27,22 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          {{ if .Values.appRedisConnection.host }}
+          - name: REDIS_HOST
+            value: {{ .Values.appRedisConnection.host | quote }}
+          {{ end }}
+          {{ if .Values.appRedisConnection.port }}
+          - name: REDIS_PORT
+            value: {{ .Values.appRedisConnection.port | quote }}
+          {{ end }}
+          {{ if .Values.appRedisConnection.db }}
+          - name: REDIS_DB
+            value: {{ .Values.appRedisConnection.db | quote }}
+          {{ end }}
+          {{ if .Values.appRedisConnection.sslCrt }}
+          - name: REDIS_SSL_CRT
+            value: {{ .Values.appRedisConnection.sslCrt | quote }}
+          {{ end }}
         ports:
         - containerPort: 8080
         resources:

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -32,4 +32,10 @@ openshift: false
 redis:
   storageClassName: standard
 
+appRedisConnection:
+  host:
+  port:
+  db:
+  sslCrt:
+
 ocCreateRoute: false

--- a/cart/package.json
+++ b/cart/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
       "body-parser": "^1.18.1",
       "express": "^4.15.4",
-      "redis": "^2.8.0",
+      "redis": "^3.1.2",
       "request": "^2.88.2",
       "pino": "^5.10.8",
       "express-pino-logger": "^4.0.0",

--- a/cart/server.js
+++ b/cart/server.js
@@ -25,8 +25,19 @@ const counter = new promClient.Counter({
 
 
 var redisConnected = false;
+let redisConnectionSettings = {}
+let redisProtocol = 'redis'
+let redisHost = process.env.REDIS_HOST || 'redis'
+let redisPort = process.env.REDIS_PORT || '6379'
+let redisDB = process.env.REDIS_DB || '0'
 
-var redisHost = process.env.REDIS_HOST || 'redis'
+if (process.env.REDIS_SSL_CRT) {
+    redisConnectionSettings.tls = {
+        ca: Buffer.from(process.env.REDIS_SSL_CRT, 'base64').toString('utf-8')
+    }
+    redisProtocol = 'rediss'
+}
+
 var catalogueHost = process.env.CATALOGUE_HOST || 'catalogue'
 
 const logger = pino({
@@ -387,9 +398,10 @@ function saveCart(id, cart) {
 }
 
 // connect to Redis
-var redisClient = redis.createClient({
-    host: redisHost
-});
+var redisClient = redis.createClient(
+    `${redisProtocol}://${redisHost}:${redisPort}/${redisDB}`, 
+    redisConnectionSettings
+);
 
 redisClient.on('error', (e) => {
     logger.error('Redis ERROR', e);

--- a/user/package.json
+++ b/user/package.json
@@ -12,7 +12,7 @@
       "body-parser": "^1.18.1",
       "express": "^4.15.4",
       "mongodb": "^3.5.3",
-      "redis": "^2.8.0",
+      "redis": "^3.1.2",
       "pino": "^5.10.8",
       "express-pino-logger": "^4.0.0",
       "pino-pretty": "^2.5.0",

--- a/user/server.js
+++ b/user/server.js
@@ -255,9 +255,23 @@ app.get('/history/:id', (req, res) => {
 });
 
 // connect to Redis
-var redisClient = redis.createClient({
-    host: process.env.REDIS_HOST || 'redis'
-});
+let redisConnectionSettings = {}
+let redisProtocol = 'redis'
+let redisHost = process.env.REDIS_HOST || 'redis'
+let redisPort = process.env.REDIS_PORT || '6379'
+let redisDB = process.env.REDIS_DB || '0'
+
+if (process.env.REDIS_SSL_CRT) {
+    redisConnectionSettings.tls = {
+        ca: Buffer.from(process.env.REDIS_SSL_CRT, 'base64').toString('utf-8')
+    }
+    redisProtocol = 'rediss'
+}
+
+var redisClient = redis.createClient(
+    `${redisProtocol}://${redisHost}:${redisPort}/${redisDB}`, 
+    redisConnectionSettings
+);
 
 redisClient.on('error', (e) => {
     logger.error('Redis ERROR', e);


### PR DESCRIPTION
This PR is adding an option to enable external redis for cart and user service. It also allows configure connection parameters like SSL, PORT and DB.