### PR TITLE
Add pod affinity, tolerations and nodeSelector for robot-shop deployments through Helm chart

### DIFF
--- a/K8s/helm/README.md
+++ b/K8s/helm/README.md
@@ -95,3 +95,6 @@ $ helm install robot-shop --set openshift=true helm
 | psp.enabled      | false | boolean | Enable Pod Security Policy for clusters with a PSP Admission controller |
 | redis.storageClassName | standard | string | Storage class to use with Redis's StatefulSet. The default for EKS is gp2. |
 | ocCreateRoute    | false | boolean | If you are running on OpenShift and need a Route to the web service, set this to `true` |
+| affinity    | {} | object | Affinity for pod assignment on nodes with matching labels (Refer [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)) |
+| nodeSelector    | {} | object | Node labels for pod assignment (Refer [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)) |
+| tolerations    | [] | list | Tolerations for pod assignment on nodes with matching taints (Refer [here](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |

--- a/K8s/helm/README.md
+++ b/K8s/helm/README.md
@@ -80,7 +80,7 @@ Openshift is like K8s but not K8s. Set `openshift` to true or things will break.
 $ helm install robot-shop --set openshift=true helm
 ```
 
-### Deployment Parameters
+## Deployment Parameters
 
 | Key              | Default | Type   | Description |
 | ---------------- | ------- | ------ | ----------- |
@@ -95,6 +95,92 @@ $ helm install robot-shop --set openshift=true helm
 | psp.enabled      | false | boolean | Enable Pod Security Policy for clusters with a PSP Admission controller |
 | redis.storageClassName | standard | string | Storage class to use with Redis's StatefulSet. The default for EKS is gp2. |
 | ocCreateRoute    | false | boolean | If you are running on OpenShift and need a Route to the web service, set this to `true` |
-| affinity    | {} | object | Affinity for pod assignment on nodes with matching labels (Refer [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)) |
-| nodeSelector    | {} | object | Node labels for pod assignment (Refer [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)) |
-| tolerations    | [] | list | Tolerations for pod assignment on nodes with matching taints (Refer [here](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |
+| `<workload>`.affinity    | {} | object | Affinity for pod assignment on nodes with matching labels (Refer [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)) |
+| `<workload>`.nodeSelector    | {} | object | Node labels for pod assignment (Refer [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)) |
+| `<workload>`.tolerations    | [] | list | Tolerations for pod assignment on nodes with matching taints (Refer [here](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |
+---
+> ### Notes for `affinity` and `tolerations`
+> `<workload>` can be substituted with the different microservices consisting of Robot shop, namely:
+> - [`cart`](./templates/cart-deployment.yaml)
+> - [`catalogue`](./templates/catalogue-deployment.yaml)
+> - [`dispatch`](./templates/dispatch-deployment.yaml)
+> - [`mongodb`](./templates/mongodb-deployment.yaml)
+> - [`mysql`](./templates/mysql-deployment.yaml)
+> - [`payment`](./templates/payment-deployment.yaml)
+> - [`rabbitmq`](./templates/rabbitmq-deployment.yaml)
+> - [`ratings`](./templates/ratings-deployment.yaml)
+> - [`redis`](./templates/redis-statefulset.yaml)
+> - [`shipping`](./templates/shipping-deployment.yaml)
+> - [`user`](./templates/user-deployment.yaml)
+> - [`web`](./templates/web-deployment.yaml)
+>
+> `affinity`, `nodeSelector` and `tolerations` can be set for individual workloads.
+------
+## Examples for deployment using `affinities` and `tolerations`
+<br />
+
+`values.yaml`
+```yaml
+.
+..
+...
+shipping:
+    gateway: null
+    affinity:
+        nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-restriction.kubernetes.io/pool_0
+                    operator: Exists
+                    values: []
+    tolerations:
+        - key: "pool_0"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+        - key: "pool_0"
+        operator: "Equal"
+        value: "true"
+        effect: "NoExecute"
+    nodeSelector: {}
+
+user:
+    affinity:
+        nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-restriction.kubernetes.io/pool_1
+                    operator: Exists
+                    values: []
+    tolerations:
+        - key: "pool_1"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+        - key: "pool_1"
+        operator: "Equal"
+        value: "true"
+        effect: "NoExecute"
+    nodeSelector: {}
+...
+..
+.
+ ```
+
+In this example, the `shipping` Pods will be deployed on only those nodes that have the label `node-restriction.kubernetes.io/pool_0` and are tainted using
+```
+kubectl taint node <node_name> pool_0=true:NoSchedule
+kubectl taint node <node_name> pool_0=true:NoExecute
+```
+
+Similarly, the `user` Pods will be deployed on only those nodes that have the label `node-restriction.kubernetes.io/pool_1` and are tainted using
+```
+kubectl taint node <node_name> pool_1=true:NoSchedule
+kubectl taint node <node_name> pool_1=true:NoExecute
+```
+
+Hence, this way we can control which `Robot shop` workloads are running on which nodes/nodepools.
+
+> *Note*: `nodeSelector` will behave in a similar fashion.

--- a/K8s/helm/templates/cart-deployment.yaml
+++ b/K8s/helm/templates/cart-deployment.yaml
@@ -36,15 +36,15 @@ spec:
           requests:
             cpu: 100m
             memory: 50Mi
-      {{- with .Values.affinity }}
+      {{- with .Values.cart.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.cart.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.cart.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/cart-deployment.yaml
+++ b/K8s/helm/templates/cart-deployment.yaml
@@ -36,3 +36,15 @@ spec:
           requests:
             cpu: 100m
             memory: 50Mi
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/catalogue-deployment.yaml
+++ b/K8s/helm/templates/catalogue-deployment.yaml
@@ -36,15 +36,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.catalogue.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.catalogue.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.catalogue.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/catalogue-deployment.yaml
+++ b/K8s/helm/templates/catalogue-deployment.yaml
@@ -36,3 +36,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/dispatch-deployment.yaml
+++ b/K8s/helm/templates/dispatch-deployment.yaml
@@ -35,3 +35,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/dispatch-deployment.yaml
+++ b/K8s/helm/templates/dispatch-deployment.yaml
@@ -35,15 +35,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.dispatch.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.dispatch.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.dispatch.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/mongodb-deployment.yaml
+++ b/K8s/helm/templates/mongodb-deployment.yaml
@@ -31,3 +31,15 @@ spec:
             cpu: 100m
             memory: 100Mi
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/mongodb-deployment.yaml
+++ b/K8s/helm/templates/mongodb-deployment.yaml
@@ -31,15 +31,15 @@ spec:
             cpu: 100m
             memory: 100Mi
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.mongodb.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.mongodb.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.mongodb.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/mysql-deployment.yaml
+++ b/K8s/helm/templates/mysql-deployment.yaml
@@ -35,3 +35,15 @@ spec:
             cpu: 100m
             memory: 700Mi
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/mysql-deployment.yaml
+++ b/K8s/helm/templates/mysql-deployment.yaml
@@ -35,15 +35,15 @@ spec:
             cpu: 100m
             memory: 700Mi
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.mysql.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.mysql.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.mysql.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/payment-deployment.yaml
+++ b/K8s/helm/templates/payment-deployment.yaml
@@ -44,15 +44,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.payment.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.payment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.payment.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/payment-deployment.yaml
+++ b/K8s/helm/templates/payment-deployment.yaml
@@ -44,3 +44,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/rabbitmq-deployment.yaml
+++ b/K8s/helm/templates/rabbitmq-deployment.yaml
@@ -32,3 +32,15 @@ spec:
             cpu: 100m
             memory: 256Mi
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/rabbitmq-deployment.yaml
+++ b/K8s/helm/templates/rabbitmq-deployment.yaml
@@ -32,15 +32,15 @@ spec:
             cpu: 100m
             memory: 256Mi
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.rabbitmq.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.rabbitmq.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.rabbitmq.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/ratings-deployment.yaml
+++ b/K8s/helm/templates/ratings-deployment.yaml
@@ -39,3 +39,15 @@ spec:
           failureThreshold: 30
           successThreshold: 1
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/ratings-deployment.yaml
+++ b/K8s/helm/templates/ratings-deployment.yaml
@@ -39,15 +39,15 @@ spec:
           failureThreshold: 30
           successThreshold: 1
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.ratings.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.ratings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.ratings.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/redis-statefulset.yaml
+++ b/K8s/helm/templates/redis-statefulset.yaml
@@ -35,6 +35,18 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/K8s/helm/templates/redis-statefulset.yaml
+++ b/K8s/helm/templates/redis-statefulset.yaml
@@ -35,15 +35,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.redis.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.redis.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.redis.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/shipping-deployment.yaml
+++ b/K8s/helm/templates/shipping-deployment.yaml
@@ -40,15 +40,15 @@ spec:
           failureThreshold: 30
           successThreshold: 1
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.shipping.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.shipping.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.shipping.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/shipping-deployment.yaml
+++ b/K8s/helm/templates/shipping-deployment.yaml
@@ -40,3 +40,15 @@ spec:
           failureThreshold: 30
           successThreshold: 1
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/user-deployment.yaml
+++ b/K8s/helm/templates/user-deployment.yaml
@@ -37,15 +37,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.user.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.user.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.user.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/templates/user-deployment.yaml
+++ b/K8s/helm/templates/user-deployment.yaml
@@ -37,3 +37,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/web-deployment.yaml
+++ b/K8s/helm/templates/web-deployment.yaml
@@ -38,3 +38,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/K8s/helm/templates/web-deployment.yaml
+++ b/K8s/helm/templates/web-deployment.yaml
@@ -38,15 +38,15 @@ spec:
             cpu: 100m
             memory: 50Mi
       restartPolicy: Always
-      {{- with .Values.affinity }}
+      {{- with .Values.web.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.web.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.web.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -33,3 +33,9 @@ redis:
   storageClassName: standard
 
 ocCreateRoute: false
+
+affinity: {}
+
+nodeSelector: {}
+
+tolerations: []

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -1,4 +1,4 @@
-# Registry and rpository for Docker images
+# Registry and repository for Docker images
 # Default is docker/robotshop/image:latest
 image:
   repo: robotshop

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -24,68 +24,41 @@ openshift: false
 
 ocCreateRoute: false
 
+######################################
+# Affinities for individual workloads
+# set in the following way:
+# <workload>:
+#   affinity: {}
+#   nodeSelector: {}
+#   tolerations: []
+######################################
+
+cart: {}
+
+catalogue: {}
+
+dispatch: {}
+
+mongodb: {}
+
+mysql: {}
+
 payment:
   # Alternative payment gateway URL
   # Default is https://www.paypal.com
   gateway: null
   #gateway: https://www.worldpay.com
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
+
+rabbitmq: {}
+
+ratings: {}
 
 redis:
   # Storage class to use with redis statefulset.
   storageClassName: standard
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
 
-cart:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
+shipping: {}
 
-catalogue:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
+user: {}
 
-dispatch:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
-
-mongodb:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
-
-mysql:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
-
-rabbitmq:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
-
-ratings:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
-
-shipping:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
-
-user:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
-
-web:
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
+web: {}

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -5,12 +5,6 @@ image:
   version: latest
   pullPolicy: IfNotPresent
 
-# Alternative payment gateway URL
-# Default is https://www.paypal.com
-payment:
-  gateway: null
-  #gateway: https://www.worldpay.com
-
 # EUM configuration
 # Provide your key and set the endpoint
 eum:
@@ -28,14 +22,70 @@ nodeport: false
 # "special" Openshift. Set to true when deploying to any openshift flavour
 openshift: false
 
-# Storage class to use with redis statefulset.
-redis:
-  storageClassName: standard
-
 ocCreateRoute: false
 
-affinity: {}
+payment:
+  # Alternative payment gateway URL
+  # Default is https://www.paypal.com
+  gateway: null
+  #gateway: https://www.worldpay.com
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
 
-nodeSelector: {}
+redis:
+  # Storage class to use with redis statefulset.
+  storageClassName: standard
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
 
-tolerations: []
+cart:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+catalogue:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+dispatch:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+mongodb:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+mysql:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+rabbitmq:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+ratings:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+shipping:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+user:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+web:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []


### PR DESCRIPTION
# Why
While deploying robot-shop using the Helm chart, there is no way to specify the affinity and tolerations for the deployment pods. 
In my use case, I have two node pools in my GKE cluster, and I need the robot-shop pods to be scheduled only on one of the 2 pools. This is possible using affinities and tolerations, but there is no support through the Helm chart, out of the box.
This commit aims to provide the support to do the same.

# What
Using the `values.yaml`,
```yaml

######################################
# Affinities for individual workloads
# set in the following way:
# <workload>:
#   affinity: {}
#   nodeSelector: {}
#   tolerations: []
######################################

cart: {}

catalogue: {}

dispatch: {}

mongodb: {}

mysql: {}

payment:
  # Alternative payment gateway URL
  # Default is https://www.paypal.com
  gateway: null
  #gateway: https://www.worldpay.com

rabbitmq: {}

ratings: {}

redis:
  # Storage class to use with redis statefulset.
  storageClassName: standard

shipping: {}

user: {}

web: {}


```
affinities and tolerations can now be set during Helm chart installation.

I updated the docs as well for examples of how to define affinities for individual workloads.
