### PR TITLE
web: Dockerfile: Replace curl with wget

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,17 +3,16 @@ ARG KEY
 
 WORKDIR /instana
 
-RUN apk add --update --no-cache curl
+RUN apk add --update --no-cache wget
 
-ENV ARTI_PATH='https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/'
+ENV ARTI_PATH='artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/'
 
 RUN if [ -n "$KEY" ]; then \
-    sensor_version=$(curl --user "_:$KEY" ${ARTI_PATH} | grep -o '>[0-9]\+\.[0-9]\+\.[0-9]\+'| cut -f 2 -d '>'|sort -V|tail -1 ); \
+    sensor_version=$(wget -O- "https://_:${KEY}@${ARTI_PATH}" 2>&1 | \
+      egrep -o "href=\"([0-9]+\.){2}[0-9]+/" | cut -d'"' -f2 | sort -V | tail -n1 | tr -d /); \
     echo "Downloading sensor version ${sensor_version} for Nginx version 1.21.6" ; \
-    curl \
-    --output instana.zip \
-    --user "_:$KEY" \
-    ${ARTI_PATH}/${sensor_version}/linux-amd64-glibc-nginx-1.21.6.zip && \
+    $(wget -O instana.zip \
+      "https://_:${KEY}@${ARTI_PATH}/${sensor_version}/linux-amd64-glibc-nginx-1.21.6.zip") && \
     unzip instana.zip && \
     mv glibc-libinstana_sensor.so libinstana_sensor.so && \
     mv glibc-nginx-1.21.6-ngx_http_ot_module.so ngx_http_opentracing_module.so; \


### PR DESCRIPTION
The `curl` command with its `libcurl` violates the SSL network state machine and closes SSL sessions three times instead of only once. This can cause `libcurl` to hang, cause TCP resets (RSTs), or corrupted files.

So use `wget` instead. Put username and password into the URI as BusyBox `wget` does not support providing those as command line options.