### PR TITLE
Update dependencies and fix build errors in dispatch and shipping services

### DIFF
--- a/dispatch/Dockerfile
+++ b/dispatch/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.22
 
 WORKDIR /go/src/app
 

--- a/dispatch/main.go
+++ b/dispatch/main.go
@@ -13,7 +13,7 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 const (

--- a/shipping/Dockerfile
+++ b/shipping/Dockerfile
@@ -3,6 +3,10 @@
 #
 FROM debian:10 AS build
 
+RUN apt-get update && apt-get install -y ca-certificates-java && \
+    apt-get clean && \
+    update-ca-certificates -f
+
 RUN apt-get update && apt-get -y install maven
 
 WORKDIR /opt/shipping


### PR DESCRIPTION
### **Description of Change:**

These changes have been tested and resolve several issues I encountered. I believe they will also likely address similar errors for others.

#### Dispatch Service:
- **Replaced Deprecated RabbitMQ Library**: Updated the RabbitMQ library in `main.go` from `github.com/streadway/amqp` to `github.com/rabbitmq/amqp091-go` to use the latest supported version.
- **Updated Go Version**: Changed the Go version in `dispatch/Dockerfile` from `golang:1.17` to `golang:1.22` to resolve a compilation error related to the missing `slices` package.

#### Shipping Service:
- **Fixed Maven Installation Error**: Added installation of `ca-certificates-java` and updated certificates in `shipping/Dockerfile` to resolve Maven installation issues during the build process.

### **Impact on Existing Behavior:**
There should be no impact on existing behavior. These changes primarily address build issues and update dependencies to ensure the services compile and run as expected without modifying functionality.