### PR TITLE
Upgrade GO for Dispatch Dockerfile

### DIFF
--- a/dispatch/Dockerfile
+++ b/dispatch/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM stevenli6186/chainguard-go:1.23.5
 
 WORKDIR /go/src/app
 


### PR DESCRIPTION
Dockerfile base image for Dispatch has been updated from go1.17 to go1.23.5