### PR TITLE
Updates EKS cluster setup with Robot Shop application deployment

### DIFF
--- a/EKS/Istio/canary.yaml
+++ b/EKS/Istio/canary.yaml
@@ -1,0 +1,35 @@
+# Canary testing using Istio
+# The DestinationRule defines the subsets by Deployment label
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: canary-test
+spec:
+  host: payment.robot-shop.svc.cluster.local
+  subsets:
+  - name: production
+    labels:
+      stage: prod
+  - name: canary
+    labels:
+      stage: test
+---
+# VirtualService subset references DestinationRule spec.subsets.name
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: robotshop-canary
+spec:
+  hosts:
+  - payment.robot-shop.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: payment.robot-shop.svc.cluster.local
+        subset: production
+      weight: 99
+    - destination:
+        host: payment.robot-shop.svc.cluster.local
+        subset: canary
+      weight: 1

--- a/EKS/Istio/gateway.yaml
+++ b/EKS/Istio/gateway.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: robotshop-gateway
+spec:
+  selector:
+    istio: ingressgateway # default Istio controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: robotshop
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - robotshop-gateway
+  http:
+  # default route
+  - route:
+    - destination:
+        host: web.robot-shop.svc.cluster.local
+        port:
+          number: 8080

--- a/EKS/Istio/payment-deployment-fix.yaml
+++ b/EKS/Istio/payment-deployment-fix.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-fix
+  labels:
+    service: payment
+    stage: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: payment
+      stage: test
+  template:
+    metadata:
+      labels:
+        service: payment
+        stage: test
+    spec:
+      containers:
+      - name: payment-fix
+        image: robotshop/rs-payment-fix:latest
+        # agent networking access
+        env:
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always

--- a/EKS/README.md
+++ b/EKS/README.md
@@ -1,0 +1,42 @@
+# Instana Agent Install
+
+The easiest way to install the Instana agent is with the helm [chart](https://hub.helm.sh/charts/stable/instana-agent). If you really want to do it by hand, template descriptors are available in the official [documentation](https://docs.instana.io/ecosystem/kubernetes/).
+
+# Stan's Robot Shop Install
+
+Install Stan's Robot Shop on to your K8s cluster using the helm chart, see the [README](helm/README.md) for details of the various options.
+
+```shell
+$ cd helm
+$ helm install --name robot-shop --namespace robot-shop .
+```
+
+## Quotas and Scaling
+
+You can apply resource quotas to the namespace where you installed Stan's Robot Shop.
+
+```shell
+$ kubectl -n robot-shop apply -f resource-quota.yaml
+```
+
+The quotas and usage are shown in the Instana Kubernetes dashboards.
+
+Optinally you can also run the `autoscale.sh` script to configure automatic scaling of the deployments. You will need to edit the script if you did not deploy to the `robot-shop` namespace. Varying the load on the application will cause Kubernetes to scale up/down the various deployments.
+
+## Istio
+
+Stan's Robot Shop will run on Kubernetes with Istio service mesh. Configure Istio ingress.
+
+```shell
+$ kubectl -n robot-shop apply -f Istio/gateway.yaml
+```
+
+Now use the exposed Istio gateway to access Robot Shop.
+
+```shell
+$ kubectl -n istio-system get svc istio-ingressgateway
+```
+
+The above will display the IP address of the Istio gateway.
+
+**NOTE** The Instana agent only works with later versions of Istio.

--- a/EKS/autoscale.sh
+++ b/EKS/autoscale.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+NS="robot-shop"
+DEPLOYMENTS="cart catalogue dispatch payment ratings shipping user web"
+
+for DEP in $DEPLOYMENTS
+do
+    kubectl -n $NS autoscale deployment $DEP --max 2 --min 1 --cpu-percent 50
+done
+
+echo "Waiting 5 seconds for changes to apply..."
+sleep 5
+kubectl -n $NS get hpa
+

--- a/EKS/helm/Chart.yaml
+++ b/EKS/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+name: robot-shop
+version: 1.1.0
+home: https://github.com/instana/robot-shop
+description: Sample micoservices application
+

--- a/EKS/helm/README.md
+++ b/EKS/helm/README.md
@@ -1,0 +1,374 @@
+# EKS Cluster Setup with eksctl and Robot Shop Microservices
+
+This repository provides a step-by-step guide to creating an Amazon Elastic Kubernetes Service (EKS) cluster using `eksctl`, deploying the Robot Shop microservices application, and configuring the AWS Load Balancer Controller with an ingress resource. It includes instructions for setting up persistent storage with the AWS EBS CSI driver and troubleshooting stateful application issues.
+
+## Features
+
+- **EKS Cluster Creation**: Uses `eksctl` to provision an EKS cluster with managed nodes in the `ap-southeast-1` region.
+- **Stateful Microservices**: Deploys the Robot Shop application with persistent storage support via the AWS EBS CSI driver for components like Redis.
+- **Ingress Controller**: Configures the AWS Load Balancer Controller with IAM Roles for Service Accounts (IRSA) to manage Application Load Balancers (ALBs).
+- **IAM OIDC Integration**: Sets up an IAM OIDC provider for secure authentication of Kubernetes service accounts.
+- **Troubleshooting Guide**: Includes steps to resolve issues with stateful applications, such as PersistentVolumeClaim (PVC) binding errors.
+- **Cleanup Instructions**: Provides commands to uninstall the application and controller for easy teardown.
+
+## Prerequisites
+
+To follow this guide, ensure you have the following:
+
+- **AWS CLI**: Configured with a profile (e.g., `terraform-cloud-user`) and permissions for EKS, IAM, VPC, and EC2 in the `ap-southeast-1` region.
+- **eksctl**: must be installed for cluster and addon management.
+- **kubectl**: For interacting with the EKS cluster.
+- **Helm**: For installing the Robot Shop application and AWS Load Balancer Controller.
+- **AWS Account**: With permissions to create EKS clusters, IAM roles, policies, and VPC resources.
+- **SSH Key (Optional)**: For Git authentication if cloning private repositories.
+
+## Repository Structure
+
+```
+.
+├── Chart.yaml
+├── ingress.yaml
+├── README.md
+├── storage-class-gp3.yml
+├── templates
+│   ├── cart-deployment.yaml
+│   ├── cart-service.yaml
+│   ├── catalogue-deployment.yaml
+│   ├── catalogue-service.yaml
+│   ├── clusterrolebinding.yaml
+│   ├── clusterrole.yaml
+│   ├── dispatch-deployment.yaml
+│   ├── dispatch-service.yaml
+│   ├── mongodb-deployment.yaml
+│   ├── mongodb-service.yaml
+│   ├── mysql-deployment.yaml
+│   ├── mysql-service.yaml
+│   ├── payment-deployment.yaml
+│   ├── payment-service.yaml
+│   ├── podsecuritypolicy.yaml
+│   ├── rabbitmq-deployment.yaml
+│   ├── rabbitmq-service.yaml
+│   ├── ratings-deployment.yaml
+│   ├── ratings-service.yaml
+│   ├── redis-service.yaml
+│   ├── redis-statefulset.yaml
+│   ├── serviceaccount.yaml
+│   ├── shipping-deployment.yaml
+│   ├── shipping-service.yaml
+│   ├── user-deployment.yaml
+│   ├── user-service.yaml
+│   ├── web-deployment.yaml
+│   └── web-service.yaml
+└── values.yaml
+```
+
+*Note*: The Robot Shop Helm chart is assumed to be available in the repository’s root directory (`.`). If hosted elsewhere, update the Helm install command accordingly.
+
+## Setup Instructions
+
+### 1. Configure AWS Credentials
+Ensure your AWS CLI is configured with the `<your-aws-profile>` profile:
+```bash
+aws configure --profile terraform-cloud-user
+```
+Set the region to `<your-aws-region>` and provide valid access/secret keys with permissions for EKS, IAM, VPC, and EC2.
+
+### 2. Clone the Repository
+```bash
+git clone https://github.com/cloudhein/robot-shop.git
+
+```
+
+### 3. Create the EKS Cluster
+Create an EKS cluster named `robot-shop-cluster` with two `t3.medium` nodes:
+```bash
+eksctl create cluster \
+  --name robot-shop-cluster \
+  --region ap-southeast-1 \
+  --profile terraform-cloud-user \
+  --nodes 2 \
+  --node-type t3.medium \
+  --nodegroup-name standard-workers
+```
+
+Verify the nodes:
+```bash
+kubectl get nodes
+```
+Expected output:
+```
+NAME                                                STATUS   ROLES    AGE   VERSION
+ip-192-168-38-159.ap-southeast-1.compute.internal   Ready    <none>   36m   v1.32.3-eks-473151a
+ip-192-168-70-10.ap-southeast-1.compute.internal    Ready    <none>   36m   v1.32.3-eks-473151a
+```
+
+### 4. Associate IAM OIDC Provider
+Set up an IAM OIDC provider for the cluster to enable IRSA:
+```bash
+export cluster_name=robot-shop-cluster
+oidc_id=$(aws eks describe-cluster --name $cluster_name --query "cluster.identity.oidc.issuer" --output text --profile terraform-cloud-user --region ap-southeast-1 | cut -d '/' -f 5)
+aws iam list-open-id-connect-providers --profile terraform-cloud-user | grep $oidc_id | cut -d "/" -f4
+eksctl utils associate-iam-oidc-provider --cluster $cluster_name --profile terraform-cloud-user --region ap-southeast-1 --approve
+```
+
+### 5. Install AWS EBS CSI Driver
+The EBS CSI driver enables persistent storage for stateful applications. Create the IAM role and service account:
+```bash
+eksctl create iamserviceaccount \
+    --name ebs-csi-controller-sa \
+    --namespace kube-system \
+    --cluster robot-shop-cluster \
+    --role-name AmazonEKS_EBS_CSI_DriverRole \
+    --role-only \
+    --attach-policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy \
+    --profile terraform-cloud-user \
+    --region ap-southeast-1 \
+    --approve
+```
+
+Install the EBS CSI driver addon:
+```bash
+eksctl create addon \
+  --name aws-ebs-csi-driver \
+  --cluster robot-shop-cluster \
+  --region ap-southeast-1 \
+  --service-account-role-arn arn:aws:iam::730335247947:role/AmazonEKS_EBS_CSI_DriverRole \
+  --profile terraform-cloud-user \
+  --force
+```
+Reference: [AWS EBS CSI Driver Documentation](https://repost.aws/knowledge-center/eks-persistent-storage)
+
+### 6. Deploy Robot Shop Microservices
+Deploy the Robot Shop application using Helm in the `robot-ns` namespace:
+```bash
+helm install robot-shop . --create-namespace -n robot-ns
+```
+
+Verify the Helm release:
+```bash
+helm list -A
+```
+Expected output:
+```
+NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
+robot-shop      robot-ns        1               2025-07-21 17:47:10.067352661 +0700 +07 deployed        robot-shop-1.1.0
+```
+
+Check the deployed pods:
+```bash
+kubectl get pods -n robot-ns
+```
+Expected output (after resolving storage issues):
+```
+NAME                        READY   STATUS    RESTARTS   AGE
+cart-655b74fb49-cqlk9       1/1     Running   0          36m
+catalogue-b4855db44-snjtk   1/1     Running   0          36m
+dispatch-845799dc84-zbxb9   1/1     Running   0          36m
+mongodb-69d9cf5747-58wdq    1/1     Running   0          36m
+mysql-8c599b989-kr29t       1/1     Running   0          36m
+payment-6589fd67f6-sgr2q    1/1     Running   0          36m
+rabbitmq-876447689-zwkqq    1/1     Running   0          36m
+ratings-6fb5c59f44-8p2v6    1/1     Running   0          36m
+redis-0                     1/1     Running   0          36m
+shipping-67cdd8c8c6-5ljj6   1/1     Running   0          36m
+user-b4977f556-cwnwf        1/1     Running   0          36m
+web-7649bf4886-hxg2d        1/1     Running   0          36m
+```
+
+### 7. Install AWS Load Balancer Controller
+Set up the IAM policy and service account for the AWS Load Balancer Controller:
+```bash
+curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.13.3/docs/install/iam_policy.json
+aws iam create-policy \
+    --policy-name AWSLoadBalancerControllerIAMPolicy \
+    --policy-document file://iam_policy.json \
+    --profile terraform-cloud-user
+eksctl create iamserviceaccount \
+    --cluster=robot-shop-cluster \
+    --namespace=kube-system \
+    --name=aws-load-balancer-controller \
+    --attach-policy-arn=arn:aws:iam::730335247947:policy/AWSLoadBalancerControllerIAMPolicy \
+    --override-existing-serviceaccounts \
+    --region ap-southeast-1 \
+    --profile terraform-cloud-user \
+    --approve
+```
+
+Install the controller using Helm:
+```bash
+helm repo add eks https://aws.github.io/eks-charts
+helm repo update eks
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+  -n kube-system \
+  --set clusterName=robot-shop-cluster \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=aws-load-balancer-controller \
+  --set vpcId=vpc-028e7e406a9a1db45 \
+  --version 1.13.0
+```
+
+Verify the Helm release:
+```bash
+helm list -A
+```
+Expected output:
+```
+NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
+aws-load-balancer-controller    kube-system     1               2025-07-21 17:57:43.027546001 +0700 +07 deployed        aws-load-balancer-controller-1.13.0     v2.13.0
+robot-shop                      robot-ns        2               2025-07-21 17:51:43.208024434 +0700 +07 deployed        robot-shop-1.1.0
+```
+
+Reference: [AWS Load Balancer Controller Documentation](https://docs.aws.amazon.com/eks/latest/userguide/lbc-helm.html)
+
+### 8. Deploy Ingress Resource
+Apply the ingress resource to expose the Robot Shop application via an Application Load Balancer (ALB):
+```bash
+kubectl apply -f ingress.yaml
+```
+
+Verify the ingress:
+```bash
+kubectl get ingress -A
+```
+Expected output:
+```
+NAMESPACE   NAME         CLASS   HOSTS   ADDRESS                                                                       PORTS   AGE
+robot-ns    robot-shop   alb     *       k8s-robotns-robotsho-bf6cb4cd48-2090334471.ap-southeast-1.elb.amazonaws.com   80      98s
+```
+
+Access the Robot Shop application using the ALB address (e.g., `http://k8s-robotns-robotsho-bf6cb4cd48-2090334471.ap-southeast-1.elb.amazonaws.com`).
+
+### 9. Troubleshoot Stateful Applications
+If the `redis-0` pod is stuck in `Pending` status due to unbound PersistentVolumeClaims (PVCs), follow these steps:
+
+Check the pod status:
+```bash
+kubectl describe pod redis-0 -n robot-ns
+```
+Example output indicating a PVC issue:
+```
+Events:
+  Type     Reason            Age                  From               Message
+  ----     ------            ----                 ----               -------
+  Warning  FailedScheduling  4m31s (x6 over 29m)  default-scheduler  0/2 nodes are available: pod has unbound immediate PersistentVolumeClaims.
+```
+
+Verify the PVC status:
+```bash
+kubectl get pvc -n robot-ns
+```
+Example output:
+```
+NAME           STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+data-redis-0   Pending                                      gp3            <unset>                 30m
+```
+
+Check available StorageClasses:
+```bash
+kubectl get storageclass
+```
+Example output:
+```
+NAME   PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+gp2    kubernetes.io/aws-ebs   Delete          WaitForFirstConsumer   false                  94m
+```
+
+The `gp3` StorageClass is missing. Create it by applying the `storage-class-gp3.yml` file:
+```bash
+kubectl apply -f storage-class-gp3.yml
+```
+Example `storage-class-gp3.yml`:
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp3
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+```
+
+Verify the StorageClass:
+```bash
+kubectl get sc
+```
+Expected output:
+```
+NAME   PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+gp2    kubernetes.io/aws-ebs   Delete          WaitForFirstConsumer   false                  100m
+gp3    kubernetes.io/aws-ebs   Delete          WaitForFirstConsumer   false                  5s
+```
+
+Recheck the pods to confirm all are running:
+```bash
+kubectl get pods -n robot-ns
+```
+Expected output:
+```
+NAME                        READY   STATUS    RESTARTS   AGE
+cart-655b74fb49-cqlk9       1/1     Running   0          36m
+catalogue-b4855db44-snjtk   1/1     Running   0          36m
+dispatch-845799dc84-zbxb9   1/1     Running   0          36m
+mongodb-69d9cf5747-58wdq    1/1     Running   0          36m
+mysql-8c599b989-kr29t       1/1     Running   0          36m
+payment-6589fd67f6-sgr2q    1/1     Running   0          36m
+rabbitmq-876447689-zwkqq    1/1     Running   0          36m
+ratings-6fb5c59f44-8p2v6    1/1     Running   0          36m
+redis-0                     1/1     Running   0          36m
+shipping-67cdd8c8c6-5ljj6   1/1     Running   0          36m
+user-b4977f556-cwnwf        1/1     Running   0          36m
+web-7649bf4886-hxg2d        1/1     Running   0          36m
+```
+
+### 10. Cleanup
+To remove the deployed resources:
+```bash
+helm uninstall aws-load-balancer-controller -n kube-system
+helm uninstall robot-shop -n robot-ns
+```
+
+To delete the EKS cluster:
+```bash
+eksctl delete cluster --name robot-shop-cluster --region ap-southeast-1 --profile terraform-cloud-user
+```
+
+## Usage Notes
+- **Region**: The commands are configured for `ap-southeast-1`. Update the `--region` flag if using a different region.
+- **Permissions**: Ensure the `terraform-cloud-user` profile has permissions for EKS, IAM, VPC, and EC2 resources.
+- **VPC ID**: Replace `vpc-028e7e406a9a1db45` in the Helm install command with your actual VPC ID, obtainable from the AWS Console (VPC > Your VPCs).
+- **IAM Role ARN**: Update `arn:aws:iam::730335247947:role/AmazonEKS_EBS_CSI_DriverRole` and `arn:aws:iam::730335247947:policy/AWSLoadBalancerControllerIAMPolicy` with your AWS account ID.
+- **Ingress YAML**: Ensure the `ingress.yaml` file is available in your repository. A sample `ingress.yaml` might look like:
+  ```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: robot-shop
+  namespace: robot-ns
+  labels:
+    app: robot-shop
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+spec:
+  ingressClassName: alb
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web
+            port:
+              number: 8080
+  ```
+- **StorageClass YAML**: The `storage-class-gp3.yml` file is included to resolve PVC issues for stateful applications like Redis.
+- **Robot Shop Helm Chart**: The `helm install robot-shop .` command assumes the chart is in the repository’s root directory. If hosted elsewhere, update the command to point to the chart’s location.
+
+## Contributing
+Contributions are welcome! Please submit a pull request or open an issue for suggestions or bug reports.
+
+## License
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/EKS/helm/ingress.yaml
+++ b/EKS/helm/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: robot-shop
+  namespace: robot-ns
+  labels:
+    app: robot-shop
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+spec:
+  ingressClassName: alb
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web
+            port:
+              number: 8080

--- a/EKS/helm/storage-class-gp3.yml
+++ b/EKS/helm/storage-class-gp3.yml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp3
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/EKS/helm/templates/cart-deployment.yaml
+++ b/EKS/helm/templates/cart-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart
+  labels:
+    service: cart
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: cart
+  template:
+    metadata:
+      labels:
+        service: cart
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: cart
+        image: {{ .Values.image.repo }}/rs-cart:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        # agent networking access
+        env:
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      {{- with .Values.cart.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cart.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cart.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/cart-service.yaml
+++ b/EKS/helm/templates/cart-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cart
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: cart

--- a/EKS/helm/templates/catalogue-deployment.yaml
+++ b/EKS/helm/templates/catalogue-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalogue
+  labels:
+    service: catalogue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: catalogue
+  template:
+    metadata:
+      labels:
+        service: catalogue
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: catalogue
+        image: {{ .Values.image.repo }}/rs-catalogue:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+      {{- with .Values.catalogue.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.catalogue.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.catalogue.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/catalogue-service.yaml
+++ b/EKS/helm/templates/catalogue-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: catalogue
+  name: catalogue
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: catalogue

--- a/EKS/helm/templates/clusterrole.yaml
+++ b/EKS/helm/templates/clusterrole.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.psp.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: robot-shop
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - robot-shop
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+{{ end }}

--- a/EKS/helm/templates/clusterrolebinding.yaml
+++ b/EKS/helm/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.psp.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: robot-shop
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: robot-shop
+subjects:
+- kind: ServiceAccount
+  name: robot-shop
+  namespace: robot-shop
+{{ end }}

--- a/EKS/helm/templates/dispatch-deployment.yaml
+++ b/EKS/helm/templates/dispatch-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dispatch
+  labels:
+    service: dispatch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: dispatch
+  template:
+    metadata:
+      labels:
+        service: dispatch
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: dispatch
+        image: {{ .Values.image.repo }}/rs-dispatch:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          # agent networking access
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+      {{- with .Values.dispatch.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dispatch.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dispatch.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/dispatch-service.yaml
+++ b/EKS/helm/templates/dispatch-service.yaml
@@ -1,0 +1,16 @@
+# dispatch just listens to a message queue
+# it does not expose any ports
+apiVersion: v1
+kind: Service
+metadata:
+  name: dispatch
+  labels:
+    service: dispatch
+spec:
+  clusterIP: None
+  ports:
+  - name: headless
+    port: 55555
+    targetPort: 0
+  selector:
+    service: dispatch

--- a/EKS/helm/templates/mongodb-deployment.yaml
+++ b/EKS/helm/templates/mongodb-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb
+  labels:
+    service: mongodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mongodb
+  template:
+    metadata:
+      labels:
+        service: mongodb
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: mongodb
+        image: {{ .Values.image.repo }}/rs-mongodb:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 27017
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      restartPolicy: Always
+      {{- with .Values.mongodb.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mongodb.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mongodb.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/mongodb-service.yaml
+++ b/EKS/helm/templates/mongodb-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: mongodb
+  name: mongodb
+spec:
+  ports:
+  - name: mongo
+    port: 27017
+    targetPort: 27017
+  selector:
+    service: mongodb

--- a/EKS/helm/templates/mysql-deployment.yaml
+++ b/EKS/helm/templates/mysql-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    service: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mysql
+  template:
+    metadata:
+      labels:
+        service: mysql
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: mysql
+        image: {{ .Values.image.repo }}/rs-mysql-db:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        # added for Istio
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN"]
+        ports:
+        - containerPort: 3306
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 700Mi
+      restartPolicy: Always
+      {{- with .Values.mysql.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mysql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mysql.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/mysql-service.yaml
+++ b/EKS/helm/templates/mysql-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: mysql
+  name: mysql
+spec:
+  ports:
+  - name: mysql
+    port: 3306
+    targetPort: 3306
+  selector:
+    service: mysql

--- a/EKS/helm/templates/payment-deployment.yaml
+++ b/EKS/helm/templates/payment-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment
+  labels:
+    service: payment
+    stage: prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: payment
+      stage: prod
+  template:
+    metadata:
+      labels:
+        service: payment
+        stage: prod
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: payment
+        image: {{ .Values.image.repo }}/rs-payment:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        # agent networking access
+        env:
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          {{- if .Values.payment.gateway }}
+          - name: PAYMENT_GATEWAY
+            value: {{ .Values.payment.gateway }}
+          {{- end }}
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+      {{- with .Values.payment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.payment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.payment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/payment-service.yaml
+++ b/EKS/helm/templates/payment-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment
+  labels:
+    service: payment
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: payment

--- a/EKS/helm/templates/podsecuritypolicy.yaml
+++ b/EKS/helm/templates/podsecuritypolicy.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.psp.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: robot-shop
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  privileged: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  allowedCapabilities:
+  - 'NET_ADMIN'
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - secret
+  - projected
+{{ end }}

--- a/EKS/helm/templates/rabbitmq-deployment.yaml
+++ b/EKS/helm/templates/rabbitmq-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  labels:
+    service: rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: rabbitmq
+  template:
+    metadata:
+      labels:
+        service: rabbitmq
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: rabbitmq
+        image: rabbitmq:3.7-management-alpine
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 5672
+        - containerPort: 15672
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+      restartPolicy: Always
+      {{- with .Values.rabbitmq.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rabbitmq.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rabbitmq.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/rabbitmq-service.yaml
+++ b/EKS/helm/templates/rabbitmq-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  labels:
+    service: rabbitmq
+spec:
+  ports:
+  - name: tcp-amqp
+    port: 5672
+    targetPort: 5672
+  - name: http-management
+    port: 15672
+    targetPort: 15672
+  - name: tcp-epmd
+    port: 4369
+    targetPort: 4369
+  selector:
+    service: rabbitmq

--- a/EKS/helm/templates/ratings-deployment.yaml
+++ b/EKS/helm/templates/ratings-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings
+  labels:
+    service: ratings
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: ratings
+  template:
+    metadata:
+      labels:
+        service: ratings
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: ratings
+        image: {{ .Values.image.repo }}/rs-ratings:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        readinessProbe:
+          httpGet:
+            path: /_health
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 30
+          successThreshold: 1
+      restartPolicy: Always
+      {{- with .Values.ratings.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ratings.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ratings.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/ratings-service.yaml
+++ b/EKS/helm/templates/ratings-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  labels:
+    service: ratings
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  selector:
+    service: ratings
+

--- a/EKS/helm/templates/redis-service.yaml
+++ b/EKS/helm/templates/redis-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: redis
+  name: redis
+spec:
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+  selector:
+    service: redis

--- a/EKS/helm/templates/redis-statefulset.yaml
+++ b/EKS/helm/templates/redis-statefulset.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    service: redis
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: redis
+  serviceName: redis
+  template:
+    metadata:
+      labels:
+        service: redis
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: redis
+        image: redis:4.0.6
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+          - name: data
+            mountPath: /mnt/redis
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+      {{- with .Values.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{ if not .Values.openshift }}
+        storageClassName: {{ .Values.redis.storageClassName }}
+        volumeMode: Filesystem
+        {{ end }}
+        resources:
+          requests:
+            storage: 1Gi
+

--- a/EKS/helm/templates/serviceaccount.yaml
+++ b/EKS/helm/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{ if .Values.psp.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: robot-shop
+  namespace: robot-shop
+{{ end }}

--- a/EKS/helm/templates/shipping-deployment.yaml
+++ b/EKS/helm/templates/shipping-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shipping
+  labels:
+    service: shipping
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: shipping
+  template:
+    metadata:
+      labels:
+        service: shipping
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: shipping
+        image: {{ .Values.image.repo }}/rs-shipping:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 8080
+        # it's Java it needs lots of memory
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 500Mi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 30
+          successThreshold: 1
+      restartPolicy: Always
+      {{- with .Values.shipping.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.shipping.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.shipping.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/shipping-service.yaml
+++ b/EKS/helm/templates/shipping-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: shipping
+  labels:
+    service: shipping
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: shipping

--- a/EKS/helm/templates/user-deployment.yaml
+++ b/EKS/helm/templates/user-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user
+  labels:
+    service: user
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: user
+  template:
+    metadata:
+      labels:
+        service: user
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: user
+        image: {{ .Values.image.repo }}/rs-user:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          # agent networking access
+          - name: INSTANA_AGENT_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+      {{- with .Values.user.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.user.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.user.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/user-service.yaml
+++ b/EKS/helm/templates/user-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user
+  labels:
+    service: user
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: user

--- a/EKS/helm/templates/web-deployment.yaml
+++ b/EKS/helm/templates/web-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  labels:
+    service: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: web
+  template:
+    metadata:
+      labels:
+        service: web
+    spec:
+      {{ if .Values.psp.enabled }}
+      serviceAccountName: robot-shop
+      {{ end }}
+      containers:
+      - name: web
+        image: {{ .Values.image.repo }}/rs-web:{{ .Values.image.version }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.eum.key }}
+        env:
+        - name: INSTANA_EUM_KEY
+          value: {{ .Values.eum.key }}
+        - name: INSTANA_EUM_REPORTING_URL
+          value: {{ .Values.eum.url }}
+        {{- end}}
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      restartPolicy: Always
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/EKS/helm/templates/web-service.yaml
+++ b/EKS/helm/templates/web-service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  labels:
+    service: web
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    service: web
+  {{ if .Values.nodeport }}
+  type: NodePort
+  {{ else }}
+  type: LoadBalancer
+  {{ end }}
+---
+{{if .Values.ocCreateRoute}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: web
+spec:
+  to:
+    kind: Service
+    name: web
+{{end}}

--- a/EKS/helm/values.yaml
+++ b/EKS/helm/values.yaml
@@ -1,0 +1,64 @@
+# Registry and repository for Docker images
+# Default is docker/robotshop/image:latest
+image:
+  repo: robotshop
+  version: latest
+  pullPolicy: IfNotPresent
+
+# EUM configuration
+# Provide your key and set the endpoint
+eum:
+  key: null
+  url: https://eum-eu-west-1.instana.io
+  #url: https://eum-us-west-2.instana.io
+
+# Pod Security Policy
+psp:
+  enabled: false
+
+# For the mini ones minikube, minishift set to true
+nodeport: true
+
+# "special" Openshift. Set to true when deploying to any openshift flavour
+openshift: false
+
+ocCreateRoute: false
+
+######################################
+# Affinities for individual workloads
+# set in the following way:
+# <workload>:
+#   affinity: {}
+#   nodeSelector: {}
+#   tolerations: []
+######################################
+
+cart: {}
+
+catalogue: {}
+
+dispatch: {}
+
+mongodb: {}
+
+mysql: {}
+
+payment:
+  # Alternative payment gateway URL
+  # Default is https://www.paypal.com
+  gateway: null
+  #gateway: https://www.worldpay.com
+
+rabbitmq: {}
+
+ratings: {}
+
+redis:
+  # Storage class to use with redis statefulset.
+  storageClassName: gp2
+
+shipping: {}
+
+user: {}
+
+web: {}

--- a/EKS/load-deployment.yaml
+++ b/EKS/load-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: load
+  labels:
+    service: load
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: load
+  template:
+    metadata:
+      labels:
+        service: load
+    spec:
+      containers:
+      - name: load
+        env:
+          - name: HOST
+            value: "http://web:8080/"
+          - name: NUM_CLIENTS
+            value: "15"
+          - name: SILENT
+            value: "1"
+          - name: ERROR
+            value: "1"
+        image: robotshop/rs-load:latest
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi

--- a/EKS/resource-quota.yaml
+++ b/EKS/resource-quota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: robot-shop-quota
+spec:
+  hard:
+    limits.cpu: 4
+    requests.cpu: 2
+    limits.memory: 5Gi
+    requests.memory: 3Gi
+    pods: 20


### PR DESCRIPTION
## Pull Request: Enhance README with Detailed EKS Cluster Setup and Robot Shop Deployment Instructions

### Description
This pull request enhances the repository's README by adding comprehensive instructions for setting up an EKS cluster using `eksctl`, deploying the Robot Shop microservices application, and configuring the AWS Load Balancer Controller with an ingress resource. It includes troubleshooting steps for resolving stateful application issues, such as PersistentVolumeClaim (PVC) binding errors, and cleanup commands for resource teardown.

### Changes
- Added step-by-step guide for:
  - Creating an EKS cluster (`robot-shop-cluster`) with `eksctl` and verifying nodes.
  - Associating an IAM OIDC provider for IRSA support.
  - Installing the AWS EBS CSI driver for persistent storage.
  - Deploying the Robot Shop application via Helm in the `robot-ns` namespace.
  - Setting up the AWS Load Balancer Controller with IAM policies and service account.
  - Applying an ingress resource to expose the application via an ALB.
- Included troubleshooting section for resolving `redis-0` pod issues by creating a `gp3` StorageClass.
- Added cleanup instructions to uninstall Helm releases and delete the EKS cluster.
- Provided sample `ingress.yaml` and `storage-class-gp3.yml` contents for clarity.
- Updated usage notes with guidance on replacing dynamic values (e.g., VPC ID, AWS account ID).
- Ensured professional formatting with clear sections, code blocks, and external references.

### Related Files
- `README.md`: Updated with detailed setup, deployment, and troubleshooting instructions.
- `storage-class-gp3.yml`: Added to resolve PVC issues for stateful applications.
- `ingress.yaml`: Added to define the ingress resource for the Robot Shop application.

### Testing
- Verified all commands locally on an Ubuntu environment with `eksctl`, `kubectl`, and `helm`.
- Confirmed successful deployment of the Robot Shop application and ingress resource.
- Tested troubleshooting steps to resolve the `redis-0` PVC issue, ensuring all pods reach `Running` status.
- Validated cleanup commands to remove resources without errors.

### Additional Notes
- The README assumes the `terraform-cloud-user` AWS profile and `ap-southeast-1` region. Users can modify these as needed.
- The `ingress.yaml` and `storage-class-gp3.yml` files are samples; adjust them based on specific chart or storage requirements.
- The AWS account ID (`730335247947`) and VPC ID (`vpc-028e7e406a9a1db45`) should be replaced with user-specific values.

Please review the changes and let me know if any adjustments are needed. Thank you for considering this contribution!